### PR TITLE
Run as user 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,8 @@ EXPOSE 8080
 
 COPY wiki.sh .
 
+# Run as the node user
+USER 1000
+
 WORKDIR /var/lib/wiki/data
 CMD /var/lib/wiki/server/wiki.sh


### PR DESCRIPTION
The node user is created when node is installed and is user 1000.
Running as this user will likely simplify file permissions when sharing
volumes since the files are probably owned by user 1000 locally anyway.